### PR TITLE
Renamed module with the PrestaShop convention for modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,7 @@ This module was desiged to load an heavy set of data into PrestaShop. Then you c
 
 ### Install and configure module
 
-Install the module:
-- use `git clone` to clone this repository inside `modules/` folder
-- make sure the folder name is `psfixturescreator` (the folder name and the main PHP module name must match)
-
+Install the module by using `git clone` to clone this repository inside `modules/` folder.
 
 ### Bash steps
 
@@ -19,11 +16,11 @@ Here is how to do the previous steps all in CLI, from the shop root folder:
 
 ```
 cd modules/
-git clone git@github.com:PrestaShop/PsFixturesCreator.git psfixturescreator
-cd psfixturescreator/
+git clone git@github.com:PrestaShop/PsFixturesCreator.git .
+cd ps_fixturescreator/
 composer install
 cd ../..
-php bin/console prestashop:module install psfixturescreator
+php bin/console prestashop:module install ps_fixturescreator
 php bin/console cache:clear
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
       "PrestaShop\\Module\\PsFixturesCreator\\": "src/"
     },
     "classmap": [
-      "psfixturescreator.php"
+      "ps_fixturescreator.php"
     ],
     "exclude-from-classmap": []
   },

--- a/config.xml
+++ b/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <module>
-    <name>psfixturescreator</name>
+    <name>ps_fixturescreator</name>
     <displayName><![CDATA[PS Fixtures Creator]]></displayName>
     <version><![CDATA[1.0.0]]></version>
     <description><![CDATA[Module to create fixtures for PrestaShop]]></description>

--- a/ps_fixturescreator.php
+++ b/ps_fixturescreator.php
@@ -13,7 +13,7 @@ class PsFixturesCreator extends Module
 {
     public function __construct()
     {
-        $this->name = 'psfixturescreator';
+        $this->name = 'ps_fixturescreator';
         $this->tab = 'administration';
         $this->version = '1.0.0';
         $this->author = 'PrestaShop';

--- a/tests/phpstan.sh
+++ b/tests/phpstan.sh
@@ -14,15 +14,15 @@ docker run -tid --rm -v ps-volume:/var/www/html --name temp-ps prestashop/presta
 # Clear previous instance of the module in the PrestaShop volume
 echo "Clear previous module"
 
-docker exec -t temp-ps rm -rf /var/www/html/modules/psfixturescreator
+docker exec -t temp-ps rm -rf /var/www/html/modules/ps_fixturescreator
 
 # Run a container for PHPStan, having access to the module content and PrestaShop sources.
 # This tool is outside the composer.json because of the compatibility with PHP 5.6
 echo "Run PHPStan using phpstan-${PS_VERSION}.neon file"
 
 docker run --rm --volumes-from temp-ps \
-       -v $PWD:/var/www/html/modules/psfixturescreator \
+       -v $PWD:/var/www/html/modules/ps_fixturescreator \
        -e _PS_ROOT_DIR_=/var/www/html \
-       --workdir=/var/www/html/modules/psfixturescreator ghcr.io/phpstan/phpstan:1 \
+       --workdir=/var/www/html/modules/ps_fixturescreator ghcr.io/phpstan/phpstan:1 \
        analyse \
-       --configuration=/var/www/html/modules/psfixturescreator/tests/phpstan/phpstan-$PS_VERSION.neon
+       --configuration=/var/www/html/modules/ps_fixturescreator/tests/phpstan/phpstan-$PS_VERSION.neon

--- a/tests/phpstan/phpstan.neon
+++ b/tests/phpstan/phpstan.neon
@@ -2,7 +2,7 @@ includes:
 	- %currentWorkingDirectory%/vendor/prestashop/php-dev-tools/phpstan/ps-module-extension.neon
 parameters:
   paths:
-    - ../../psfixturescreator.php
+    - ../../ps_fixturescreator.php
     - ../../src/
   level: 5
   ignoreErrors:


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | All the PrestaShop modules are named `ps_mymodule`. 
| Type?             | refactor
| BC breaks?        | yes
| Deprecations?     | no
| Sponsor company   | PrestaShop SA
| How to test?      | CI is green

We also need to rename the repository. I don't have this permission. 