### PR TITLE
fix order creation on PrestaShop V9

### DIFF
--- a/src/Creator/OrderCreator.php
+++ b/src/Creator/OrderCreator.php
@@ -4,7 +4,9 @@ namespace PrestaShop\Module\ps_fixturescreator\Creator;
 
 use Address;
 use Cart;
+use Context;
 use Customer;
+use Employee;
 use Faker\Generator as Faker;
 use Order;
 use OrderState;
@@ -25,6 +27,12 @@ class OrderCreator
         $this->faker = $faker;
         $this->cartCreator = $cartCreator;
         $this->customerCreator = $customerCreator;
+
+        // Because we could be in CLI mode, there might be no employee in context, so we must set it manually
+        $context = Context::getContext();
+        if (!isset($context->employee) || !isset($context->employee->id)) {
+            $context->employee = new Employee(1);
+        }
     }
 
     public function generate(int $number, int $idShopGroup, int $idShop, array $productIds): void


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Since PrestaShop V9 an employee id must be set in context if no cart id is set, it makes sense in real use cases, when used in CLI for fixtures we need to set an employee id
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| Sponsor company   | PrestaShop SA
| How to test?      | `php bin/console prestashop:shop-creator --orders=10`