### PR TITLE
Added option `stockMovements` for the command `prestashop:product-creator` (with combinations)

### DIFF
--- a/src/Command/ProductCreatorCommand.php
+++ b/src/Command/ProductCreatorCommand.php
@@ -108,6 +108,7 @@ class ProductCreatorCommand extends Command
                 $numberOfFeatures,
                 $numberOfFeatureValues,
                 $numberOfImages,
+                $numberOfStockMovements,
                 $shopId
             );
             $output->writeln(sprintf('%s product(s) with combinations created', $productsWithCombinations));

--- a/src/Creator/AbstractProductCreator.php
+++ b/src/Creator/AbstractProductCreator.php
@@ -85,13 +85,13 @@ abstract class AbstractProductCreator
         }
     }
 
-    protected function associateStockMovements(int $productId, int $numberOfStockMovements): void
+    protected function associateStockMovements(int $productId, array $combinationsId, int $numberOfStockMovements): void
     {
         if ($numberOfStockMovements <= 0) {
             return;
         }
 
-        $this->stockMovementCreator->generate($numberOfStockMovements, $productId);
+        $this->stockMovementCreator->generate($numberOfStockMovements, $productId, $combinationsId);
     }
 
     protected function associateImages(int $productId, array $combinationsId, int $numberOfImages): void

--- a/src/Creator/ProductCombinationCreator.php
+++ b/src/Creator/ProductCombinationCreator.php
@@ -54,6 +54,7 @@ class ProductCombinationCreator extends AbstractProductCreator
         int $numberOfFeatures,
         int $numberOfFeatureValues,
         int $numberOfImages,
+        int $numberOfStockMovements,
         int $shopId
     ): void {
         $attributeGroups = $this->getAttributeGroupWithAtLeast($attributeValuePerGroupNumber);
@@ -107,6 +108,7 @@ class ProductCombinationCreator extends AbstractProductCreator
             }, $combinationsIds);
 
             $this->associateImages($newProductId->getValue(), $combinationsIds, $numberOfImages);
+            $this->associateStockMovements($newProductId->getValue(), $combinationsIds, $numberOfStockMovements);
             $this->associateFeatures($newProductId->getValue(), $numberOfFeatures, $numberOfFeatureValues, $shopId);
         }
     }

--- a/src/Creator/ProductCreator.php
+++ b/src/Creator/ProductCreator.php
@@ -36,7 +36,7 @@ class ProductCreator extends AbstractProductCreator
         for ($i = 0; $i < $number; ++$i) {
             $productId = $this->createProduct($shopId);
             $this->associateImages($productId, [], $numberOfImages);
-            $this->associateStockMovements($productId, $numberOfStockMovements);
+            $this->associateStockMovements($productId, [null], $numberOfStockMovements);
             $this->associateFeatures($productId, $numberOfFeatures, $numberOfFeatureValues, $shopId);
         }
     }

--- a/src/Creator/StockMovementCreator.php
+++ b/src/Creator/StockMovementCreator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PrestaShop\Module\PsFixturesCreator\Creator;
 
 use DateTime;
@@ -25,26 +27,28 @@ class StockMovementCreator
         $this->employee = new Employee(1);
     }
 
-    public function generate(int $number, int $productId): void
+    public function generate(int $number, int $productId, array $combinationsId = []): void
     {
-        // Start
-        $qtyProduct = 500;
+        foreach ($combinationsId as $combinationId) {
+            // Start
+            $qtyProduct = 500;
 
-        StockAvailable::setQuantity($productId, 0, $qtyProduct, null, false);
+            StockAvailable::setQuantity($productId, $combinationId, $qtyProduct, null, false);
 
-        for ($i = 0; $i < $number; ++$i) {
-            $deltaQuantity = rand(-10, 10);
+            for ($i = 0; $i < $number; ++$i) {
+                $deltaQuantity = rand(-10, 10);
 
-            $qtyProduct += $deltaQuantity;
-            $this->createStockMovement($productId, $deltaQuantity);
+                $qtyProduct += $deltaQuantity;
+                $this->createStockMovement($productId, $combinationId, $deltaQuantity);
+            }
+
+            StockAvailable::setQuantity($productId, $combinationId, $qtyProduct, null, false);
         }
-
-        StockAvailable::setQuantity($productId, 0, $qtyProduct, null, false);
     }
 
-    public function createStockMovement(int $productId, int $deltaQuantity): void
+    public function createStockMovement(int $productId, ?int $combinationId, int $deltaQuantity): void
     {
-        $stockAvailable = $this->stockManager->getStockAvailableByProduct(new Product($productId));
+        $stockAvailable = $this->stockManager->getStockAvailableByProduct(new Product($productId), $combinationId);
 
         $stockMvt = new StockMvt();
         $stockMvt->setIdStock((int) $stockAvailable->id);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Added option `stockMovements` for the command `prestashop:product-creator` (with combinations)
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is :green_circle: 
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp